### PR TITLE
Bubble `didTransition` fixes #4

### DIFF
--- a/addon/mixins/keen-track-pageview.js
+++ b/addon/mixins/keen-track-pageview.js
@@ -173,9 +173,10 @@ export default Mixin.create({
 
   actions: {
     didTransition() {
+      this._super(...arguments);
       this._trackPageViewWithRender();
 
-      return this._super(...arguments);
+      return true;
     }
   }
 


### PR DESCRIPTION
This will keep event bubbling working.